### PR TITLE
Update for CGAL 6 and add K-order Delaunay vertex tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,26 @@
 # CMake for order-k Delaunay triangulations using CGAL.
 # Includes a commandline tool (main) and tests (test).
 
-project (rhomboid)
+cmake_minimum_required(VERSION 3.16)
+project(rhomboid CXX)
 
-cmake_minimum_required(VERSION 2.8.11)
-if(POLICY CMP0043)
-  cmake_policy(SET CMP0043 OLD)
-endif()
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-add_definitions(-std=c++11)
-
-find_package(CGAL COMPONENTS)
-include(${CGAL_USE_FILE}) 
-
-if ( CGAL_FOUND )
+find_package(CGAL REQUIRED COMPONENTS)
+include(${CGAL_USE_FILE})
 
 set(DEPENDENCIES src/rhomboid.cpp src/utils.cpp)
 
 add_executable(main src/main.cpp ${DEPENDENCIES})
+add_executable(VerticesKOrderDelaunay src/vertices_korder_delaunay.cpp ${DEPENDENCIES})
 add_executable(tests_2d src/tests_2d.cpp ${DEPENDENCIES})
 add_executable(tests_3d src/tests_3d.cpp ${DEPENDENCIES})
-add_to_cached_list( CGAL_EXECUTABLE_TARGETS main)
-target_link_libraries( main ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES})
 
-else()
-
-  message(STATUS "NOTICE: This demo requires CGAL, and will not be compiled.")
-
-endif()
+target_link_libraries(main ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES})
+target_link_libraries(VerticesKOrderDelaunay ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES})
+target_link_libraries(tests_2d ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES})
+target_link_libraries(tests_3d ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES})
+target_include_directories(tests_2d PRIVATE ${CMAKE_SOURCE_DIR})
+target_include_directories(tests_3d PRIVATE ${CMAKE_SOURCE_DIR})

--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ https://github.com/geoo89/orderkdelaunay obsolete.
 
 ## Prerequisites
 
-_Prerequisites:_ cmake, CGAL version <= 4.9, Catch2 (included);
-to work with CGAL version >= 4.10, some typedefs need to be changed,
-see `src/dimensional_traits_2.h` and `src/dimensional_traits_3.h`.
+_Prerequisites:_ cmake, a C++17 compiler, and a recent
+[CGAL](https://www.cgal.org/) release (tested with CGAL 6). Catch2 is
+included with the source.
 
 The build setup builds a commandline tool and tests. To build, run:
 ```
@@ -115,3 +115,19 @@ type is defined in the respective class definition, with the exception of
 CCell, which is a `std::vector` of `std::vector` of `int`s and is output in 
 the list format used in python, i.e. comma separated values wrapped in square
 brackets.
+
+## VerticesKOrderDelaunay
+
+The repository also provides the `VerticesKOrderDelaunay` executable which
+outputs the vertices of a k-order Delaunay mosaic. Usage:
+
+```
+VerticesKOrderDelaunay input.xyz k output.txt
+```
+
+`input.xyz` contains one 3D point per line. `k` is the desired order and
+`output.txt` will contain one vertex per line as a list of point indices.
+
+See `notebooks/compare_vertices.ipynb` for a Colab notebook comparing the
+output of this program to the Python implementation from
+[orderkdelaunay](https://github.com/geoo89/orderkdelaunay).

--- a/notebooks/compare_vertices.ipynb
+++ b/notebooks/compare_vertices.ipynb
@@ -1,0 +1,68 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compare Vertices of K-order Delaunay"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!apt-get update && apt-get install -y libcgal-dev cmake g++\n",
+    "!cmake -S . -B build\n",
+    "!cmake --build build --target VerticesKOrderDelaunay\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "np.random.seed(0)\n",
+    "pts = np.random.rand(100,3)\n",
+    "np.savetxt('points.xyz', pts)\n",
+    "import subprocess\n",
+    "subprocess.run(['./build/VerticesKOrderDelaunay','points.xyz','3','vertices.txt'], check=True)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!git clone https://github.com/geoo89/orderkdelaunay orderkd\n",
+    "import sys, numpy as np\n",
+    "sys.path.append('orderkd/python')\n",
+    "from orderk_delaunay import OrderKDelaunay\n",
+    "points = np.loadtxt('points.xyz').tolist()\n",
+    "okd = OrderKDelaunay(points, 3)\n",
+    "py_vertices = {tuple(sorted(v)) for v in okd.diagrams_vertices[2]}\n",
+    "with open('vertices.txt') as f:\n",
+    "    our_vertices = {tuple(map(int,line.split())) for line in f if line.strip()}\n",
+    "print('equal', py_vertices == our_vertices)\n",
+    "print('count', len(our_vertices))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/dimensional_traits_2.h
+++ b/src/dimensional_traits_2.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <CGAL/Regular_triangulation_2.h>
+#include <CGAL/Regular_triangulation_vertex_base_2.h>
+#include <CGAL/Regular_triangulation_face_base_2.h>
 #include <CGAL/Triangulation_vertex_base_with_info_2.h>
-// CGAL <4.10
-#include <CGAL/Regular_triangulation_euclidean_traits_2.h>
 
 #include <vector>
 
@@ -20,29 +20,13 @@ class DimensionalTraits_2 {
     typedef typename K::Circle_2                                                     Sphere;
     typedef typename K::FT                                                               FT;
 
-    // CGAL 4.10 breaks some backward compatibility.
-    // This code is for CGAL <4.10, but replacing the typedefs below
-    // should make to code compile for later CGAL versions.
-
-    // If using CGAL <4.10:
-    typedef typename CGAL::Regular_triangulation_euclidean_traits_2<K>               Traits;
-    typedef typename CGAL::Regular_triangulation_vertex_base_2<Traits>                Vbase;
-    typedef typename CGAL::Triangulation_vertex_base_with_info_2<PIndex, Traits,Vbase>   Vb;
-    typedef typename CGAL::Regular_triangulation_face_base_2<Traits>                     Fb;
-    typedef typename CGAL::Triangulation_data_structure_2<Vb,Fb>                        Tds;
-    typedef typename CGAL::Regular_triangulation_2<Traits, Tds>       Regular_triangulation;
-    typedef typename Traits::Weighted_point_2                                Weighted_point;
-    typedef typename Regular_triangulation::Finite_faces_iterator
-                                                Regular_triangulation_finite_cells_iterator;
-
-    // If using CGAL >=4.10:
-    // typedef typename K::FT                                               Weight;
-    // typedef typename K::Weighted_point_2                                 Weighted_point;
-    // typedef typename CGAL::Regular_triangulation_vertex_base_2<K>        Vb0;
-    // typedef typename CGAL::Triangulation_vertex_base_with_info_2<PIndex, K, Vb0> Vb;
-    // typedef typename CGAL::Regular_triangulation_face_base_2<K>          Fb;
-    // typedef typename CGAL::Triangulation_data_structure_2<Vb,Fb>         Tds;
-    // typedef typename CGAL::Regular_triangulation_2<K, Tds>               Reg_Tri;
+    typedef typename K::Weighted_point_2                                 Weighted_point;
+    typedef CGAL::Regular_triangulation_vertex_base_2<K>                 Vb0;
+    typedef CGAL::Triangulation_vertex_base_with_info_2<PIndex, K, Vb0>  Vb;
+    typedef CGAL::Regular_triangulation_face_base_2<K>                   Fb;
+    typedef CGAL::Triangulation_data_structure_2<Vb, Fb>                 Tds;
+    typedef CGAL::Regular_triangulation_2<K, Tds>                        Regular_triangulation;
+    typedef typename Regular_triangulation::Finite_faces_iterator        Regular_triangulation_finite_cells_iterator;
 
     static Regular_triangulation_finite_cells_iterator
     get_finite_cells_begin(const Regular_triangulation& T) {return T.finite_faces_begin();}

--- a/src/dimensional_traits_3.h
+++ b/src/dimensional_traits_3.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <CGAL/Regular_triangulation_3.h>
+#include <CGAL/Regular_triangulation_vertex_base_3.h>
+#include <CGAL/Regular_triangulation_cell_base_3.h>
 #include <CGAL/Triangulation_vertex_base_with_info_3.h>
-// CGAL <4.10
-#include <CGAL/Regular_triangulation_euclidean_traits_3.h>
 
 #include <vector>
 
@@ -20,29 +20,13 @@ class DimensionalTraits_3 {
     typedef typename K::Sphere_3                                                     Sphere;
     typedef typename K::FT                                                               FT;
 
-    // CGAL 4.10 breaks some backward compatibility.
-    // This code is for CGAL <4.10, but replacing the typedefs below
-    // should make to code compile for later CGAL versions.
-
-    // If using CGAL <4.10:
-    typedef typename CGAL::Regular_triangulation_euclidean_traits_3<K>               Traits;
-    typedef typename CGAL::Triangulation_vertex_base_3<Traits>                        Vbase;
-    typedef typename CGAL::Triangulation_vertex_base_with_info_3<PIndex, Traits,Vbase>   Vb;
-    typedef typename CGAL::Regular_triangulation_cell_base_3<Traits>                     Cb;
-    typedef typename CGAL::Triangulation_data_structure_3<Vb,Cb>                        Tds;
-    typedef typename CGAL::Regular_triangulation_3<Traits, Tds>       Regular_triangulation;
-    typedef typename Traits::Weighted_point_3                                Weighted_point;
-    typedef typename Regular_triangulation::Finite_cells_iterator
-                                                Regular_triangulation_finite_cells_iterator;
-
-    // If using CGAL >=4.10:
-    // typedef typename K::FT                                               Weight;
-    // typedef typename K::Weighted_point_3                                 Weighted_point;
-    // typedef typename CGAL::Regular_triangulation_vertex_base_3<K>        Vb0;
-    // typedef typename CGAL::Triangulation_vertex_base_with_info_3<PIndex, K, Vb0> Vb;
-    // typedef typename CGAL::Regular_triangulation_cell_base_3<K>          Cb;
-    // typedef typename CGAL::Triangulation_data_structure_3<Vb,Cb>         Tds;
-    // typedef typename CGAL::Regular_triangulation_3<K, Tds>               Reg_Tri;
+    typedef typename K::Weighted_point_3                                 Weighted_point;
+    typedef CGAL::Regular_triangulation_vertex_base_3<K>                 Vb0;
+    typedef CGAL::Triangulation_vertex_base_with_info_3<PIndex, K, Vb0>  Vb;
+    typedef CGAL::Regular_triangulation_cell_base_3<K>                   Cb;
+    typedef CGAL::Triangulation_data_structure_3<Vb, Cb>                 Tds;
+    typedef CGAL::Regular_triangulation_3<K, Tds>                        Regular_triangulation;
+    typedef typename Regular_triangulation::Finite_cells_iterator        Regular_triangulation_finite_cells_iterator;
 
     static Regular_triangulation_finite_cells_iterator
     get_finite_cells_begin(const Regular_triangulation& T) {return T.finite_cells_begin();}

--- a/src/tests_2d.cpp
+++ b/src/tests_2d.cpp
@@ -15,6 +15,7 @@
 #include "bifiltration_cell.h"
 #include "combinatorial_bifiltration_cell.h"
 
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
 #define CATCH_CONFIG_MAIN
 #include "catch2/catch.hpp"
 

--- a/src/tests_3d.cpp
+++ b/src/tests_3d.cpp
@@ -13,6 +13,7 @@
 #include "bifiltration_cell.h"
 #include "combinatorial_bifiltration_cell.h"
 
+#define CATCH_CONFIG_NO_POSIX_SIGNALS
 #define CATCH_CONFIG_MAIN
 #include "catch2/catch.hpp"
 

--- a/src/vertices_korder_delaunay.cpp
+++ b/src/vertices_korder_delaunay.cpp
@@ -1,0 +1,76 @@
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+
+#include "dimensional_traits_3.h"
+#include "rhomboid_tiling.h"
+
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel K;
+typedef DimensionalTraits_3<K> Dt3;
+
+template<class Dt>
+std::vector<typename Dt::Point> read_points(std::istream &stream) {
+    std::vector<typename Dt::Point> points;
+    for (std::string s; std::getline(stream, s);) {
+        if (s.empty() || s[0] == '#')
+            continue;
+        std::stringstream ss(s);
+        std::vector<double> p;
+        double v;
+        while (!ss.eof()) {
+            ss >> v;
+            if (ss.fail()) break;
+            p.push_back(v);
+        }
+        if (p.size() == Dt::dimension) {
+            points.push_back(Dt::make_point(p));
+        } else if (!p.empty()) {
+            return std::vector<typename Dt::Point>();
+        }
+    }
+    return points;
+}
+
+int main(int argc, char** argv) {
+    if (argc != 4) {
+        std::cerr << "Usage: VerticesKOrderDelaunay input.xyz k output.txt" << std::endl;
+        return 1;
+    }
+    std::ifstream infile(argv[1]);
+    if (!infile) {
+        std::cerr << "input file not found" << std::endl;
+        return 1;
+    }
+    int k = std::atoi(argv[2]);
+    if (k <= 0) {
+        std::cerr << "invalid k" << std::endl;
+        return 1;
+    }
+    std::ofstream outfile(argv[3]);
+    if (!outfile) {
+        std::cerr << "output file not found" << std::endl;
+        return 1;
+    }
+    auto points = read_points<Dt3>(infile);
+    if (points.empty()) {
+        std::cerr << "invalid input format" << std::endl;
+        return 1;
+    }
+    if (k > static_cast<int>(points.size())) {
+        k = points.size();
+    }
+    RhomboidTiling<Dt3> rt(points, k);
+    auto vertices = rt.get_vertices(k);
+    for (const auto& v : vertices) {
+        for (std::size_t i = 0; i < v.size(); ++i) {
+            if (i) outfile << ' ';
+            outfile << v[i];
+        }
+        outfile << '\n';
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- modernize build system for CGAL 6 and C++17
- add VerticesKOrderDelaunay program to extract k-order Delaunay vertices
- provide Colab notebook comparing results with python implementation

## Testing
- `cmake -S . -B build`
- `cmake --build build --target VerticesKOrderDelaunay tests_2d tests_3d`
- `./build/tests_2d`
- `./build/tests_3d`


------
https://chatgpt.com/codex/tasks/task_b_68bafec745ec8326aa94539a201be062