### PR TITLE
Add radius output for k-order Delaunay vertices

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,14 +119,16 @@ brackets.
 ## VerticesKOrderDelaunay
 
 The repository also provides the `VerticesKOrderDelaunay` executable which
-outputs the vertices of a k-order Delaunay mosaic. Usage:
+outputs the vertices of a k-order Delaunay mosaic together with their
+filtration value. Usage:
 
 ```
 VerticesKOrderDelaunay input.xyz k output.txt
 ```
 
 `input.xyz` contains one 3D point per line. `k` is the desired order and
-`output.txt` will contain one vertex per line as a list of point indices.
+`output.txt` will contain one vertex per line as a list of point indices
+followed by the radius of the smallest sphere containing these `k` points.
 
 See `notebooks/compare_vertices.ipynb` for a Colab notebook comparing the
 output of this program to the Python implementation from

--- a/notebooks/compare_vertices.ipynb
+++ b/notebooks/compare_vertices.ipynb
@@ -23,14 +23,15 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
+    "source": [
     "import numpy as np\n",
     "np.random.seed(0)\n",
     "pts = np.random.rand(100,3)\n",
     "np.savetxt('points.xyz', pts)\n",
+    "k = 3\n",
     "import subprocess\n",
-    "subprocess.run(['./build/VerticesKOrderDelaunay','points.xyz','3','vertices.txt'], check=True)\n"
-   ]
+    "subprocess.run(['./build/VerticesKOrderDelaunay','points.xyz',str(k),'vertices.txt'], check=True)\n"
+    ]
   },
   {
    "cell_type": "code",
@@ -43,13 +44,13 @@
     "sys.path.append('orderkd/python')\n",
     "from orderk_delaunay import OrderKDelaunay\n",
     "points = np.loadtxt('points.xyz').tolist()\n",
-    "okd = OrderKDelaunay(points, 3)\n",
-    "py_vertices = {tuple(sorted(v)) for v in okd.diagrams_vertices[2]}\n",
+    "okd = OrderKDelaunay(points, k)\n",
+    "py_vertices = {tuple(sorted(v)) for v in okd.diagrams_vertices[k-1]}\n",
     "with open('vertices.txt') as f:\n",
-    "    our_vertices = {tuple(map(int,line.split())) for line in f if line.strip()}\n",
+    "    our_vertices = {tuple(sorted(map(int,line.split()[:k]))) for line in f if line.strip()}\n",
     "print('equal', py_vertices == our_vertices)\n",
     "print('count', len(our_vertices))\n"
-   ]
+    ]
   }
  ],
  "metadata": {

--- a/src/vertices_korder_delaunay.cpp
+++ b/src/vertices_korder_delaunay.cpp
@@ -1,4 +1,5 @@
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/number_utils.h>
 
 #include "dimensional_traits_3.h"
 #include "rhomboid_tiling.h"
@@ -64,13 +65,20 @@ int main(int argc, char** argv) {
         k = points.size();
     }
     RhomboidTiling<Dt3> rt(points, k);
-    auto vertices = rt.get_vertices(k);
-    for (const auto& v : vertices) {
-        for (std::size_t i = 0; i < v.size(); ++i) {
-            if (i) outfile << ' ';
-            outfile << v[i];
+    auto bf = rt.get_delaunay_filtration(k);
+    auto id_map = rt.get_bifiltration_id_map();
+    for (const auto& c : bf) {
+        if (c.d == 0 && c.k == k && c.id < static_cast<int>(id_map.size())) {
+            const auto& cell = id_map[c.id];
+            if (cell.empty()) continue;
+            const auto& vx = cell[0];
+            for (std::size_t i = 0; i < vx.size(); ++i) {
+                if (i) outfile << ' ';
+                outfile << vx[i];
+            }
+            if (!vx.empty()) outfile << ' ';
+            outfile << CGAL::to_double(c.r) << '\n';
         }
-        outfile << '\n';
     }
     return 0;
 }


### PR DESCRIPTION
## Summary
- Optimize VerticesKOrderDelaunay to derive vertices via `get_delaunay_filtration` and write radius values
- Document new output format and update comparison notebook

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `build/tests_2d`
- `build/tests_3d`


------
https://chatgpt.com/codex/tasks/task_b_68bb1a70c5f88326bc292de078848dfe